### PR TITLE
Migrate to AndroidX.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/seacat/src/main/java/com/teskalabs/seacat/SeaCat.kt
+++ b/seacat/src/main/java/com/teskalabs/seacat/SeaCat.kt
@@ -16,8 +16,7 @@ class SeaCat(internal val context: Context, internal val title: String, internal
         const val ACTION_IDENTITY_RESET = "com.teskalabs.seacat.intent.action.IDENTITY_RESET"
     }
 
+    internal val broadcastManager = LocalBroadcastManager.getInstance(context)
     val identity = Identity(this)
     val peer = Peer(this)
-
-    internal val broadcastManager = LocalBroadcastManager.getInstance(context)
 }

--- a/seacat/src/main/java/com/teskalabs/seacat/SeaCat.kt
+++ b/seacat/src/main/java/com/teskalabs/seacat/SeaCat.kt
@@ -1,7 +1,7 @@
 package com.teskalabs.seacat
 
 import android.content.Context
-import android.support.v4.content.LocalBroadcastManager
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import java.security.cert.CertificateFactory
 import java.util.concurrent.Executors
 


### PR DESCRIPTION
As per Android docs:

```
AndroidX is a major improvement to the original Android Support Library. Like the Support Library, AndroidX ships separately from the Android OS and provides backwards-compatibility across Android releases.
```

This pull request instructs gradle to use AndroidX within this project.